### PR TITLE
Random nick if empty, disallow whitespace-only ones

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -264,9 +264,8 @@ window.onload = function() {
   // Sends nickname to socket
   function sendNick() {
     var nick = nickField.value;
-    if (!nick) {
-      alert('You must enter a nickname.');
-      return false;
+    if (!nick || (nick.trim() == "")) {
+      nick = "Guest" + Math.floor(Math.random() * 10000000);
     }
     socket.emit('nick', nick, playerId);
     isPlay = true;


### PR DESCRIPTION
This will allow players clicking on the "Play" button without being forced to enter in a nick and, if they fail to provide a nickname one will be randomly chosen for them (similar to agar.io and slither.io).
